### PR TITLE
Add percent change to the !price response

### DIFF
--- a/utils/price.js
+++ b/utils/price.js
@@ -12,25 +12,24 @@ async function price(msg) {
     if (info == "error ocurred") {
         msg.channel.send(info.toString() + " Maybe wrong currency code?");
     } else {
-        let value1, value2, value3;
-        try {
-            value1 = info.price.toLocaleString(number_format, { style: 'currency', currency: info.currency, minimumFractionDigits: 4 });
-            value2 = info.volume_24h.toLocaleString(number_format, { style: 'currency', currency: info.currency, minimumFractionDigits: 2 });
-            value3 = info.market_cap.toLocaleString(number_format, { style: 'currency', currency: info.currency, minimumFractionDigits: 2 });
-        } catch (error) {
-            value1 = info.price.toLocaleString(number_format, { minimumFractionDigits: 4 }) + " " + info.currency;
-            value2 = info.volume_24h.toLocaleString(number_format, { minimumFractionDigits: 2 }) + " " + info.currency;
-            value3 = info.market_cap.toLocaleString(number_format, { minimumFractionDigits: 2 }) + " " + info.currency;
-        }
+        let price = formatCurrency(info.price, info.currency, 4)
+        let volume_24h = formatCurrency(info.volume_24h, info.currency, 2)
+        let market_cap = formatCurrency(info.market_cap, info.currency, 2)
+        let hr1_change = formatNumber(info.percent_change_1h, 2)
+        let hr24_change = formatNumber(info.percent_change_24h, 2)
+        let d7_change = formatNumber(info.percent_change_7d, 2)
         let embed = new MessageEmbed()
             .setColor('#E67E22')
             .setTitle('CoinMarketCap Garlicoin Info')
             .setURL('https://coinmarketcap.com/currencies/garlicoin/')
             .setThumbnail('https://s2.coinmarketcap.com/static/img/coins/64x64/2475.png')
             .addFields(
-                { name: 'Price', value: value1 },
-                { name: 'Volume 24h', value: value2 },
-                { name: 'Market Cap', value: value3 }
+                { name: 'Price', value: price },
+                { name: 'Volume 24h', value: volume_24h },
+                { name: 'Market Cap', value: market_cap },
+                { name: '1hr Price Change', value: formatLossGain(hr1_change), inline: true },
+                { name: '24hr Price Change', value: formatLossGain(hr24_change), inline: true },
+                { name: '7d Price Change', value: formatLossGain(d7_change), inline: true },
             )
             .setFooter('Last Updated: ' + info.lastUpdate);
         msg.channel.send({ embeds: [embed] });
@@ -38,5 +37,27 @@ async function price(msg) {
 
 }
 
+/*
+    Values starting with "-" will be red
+    values starting with "+" turn green
+    values without either are white
+ */
+function formatLossGain(value){
+    if(value>0) value = "+" + value
+    value = value + "%"
+    return "```diff\n"+value+"\n```"
+}
+
+function formatCurrency(value, currency, minimumFractionDigits){
+    try{
+        return value.toLocaleString(number_format, { style: 'currency', currency: currency, minimumFractionDigits: minimumFractionDigits });
+    }catch(error){
+        return formatNumber(value, minimumFractionDigits) + " " + currency;
+    }
+}
+
+function formatNumber(value, minimumFractionDigits){
+    return value.toLocaleString(number_format, { minimumFractionDigits: minimumFractionDigits });
+}
 
 export { price };

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -31,13 +31,9 @@ async function getCMC(currency = "USD") {
     if (currentTime - cmcJSON.times[currentCurrency] >= 200 || cmcJSON.times[currentCurrency] == undefined) { // 3-4 mins
         await axios(requestOptions).then(response => {
             garlicoinINFO = response.data.data.GRLC.quote[currencyAPI];
-            cmcJSON.values[currentCurrency] = {
-                "price": garlicoinINFO.price,
-                "volume_24h": garlicoinINFO.volume_24h,
-                "market_cap": garlicoinINFO.market_cap,
-                "currency": currentCurrency,
-                "lastUpdate": "Right Now"
-            };
+            garlicoinINFO["lastUpdate"] = "Right Now"
+            garlicoinINFO["currency"] = currentCurrency
+            cmcJSON.values[currentCurrency] = garlicoinINFO
             cmcJSON.times[currentCurrency] = currentTime;
             setDatabase('cmc', cmcJSON);
         }).catch((err) => {
@@ -50,13 +46,8 @@ async function getCMC(currency = "USD") {
             return cmcJSON.values[currentCurrency];
         }
     } else {
-        const savedCMC = {
-            "price": cmcJSON.values[currentCurrency].price,
-            "volume_24h": cmcJSON.values[currentCurrency].volume_24h,
-            "market_cap": cmcJSON.values[currentCurrency].market_cap,
-            "currency": cmcJSON.values[currentCurrency].currency,
-            "lastUpdate": (currentTime - cmcJSON.times[currentCurrency]).toString() + " seconds ago"
-        }
+        const savedCMC = cmcJSON.values[currentCurrency];
+        savedCMC.lastUpdate = (currentTime - cmcJSON.times[currentCurrency]).toString() + " seconds ago"
         return savedCMC;
     }
 }


### PR DESCRIPTION
Adds a row below the existing price information to show the %change in the last 1hr, 24hr, and 7d.
The percent changes are colored according to their values

<img width="378" alt="price_change" src="https://user-images.githubusercontent.com/9167204/140660913-76539c48-14f2-4972-9185-52e268131500.png">

note: This doesn't look as great on mobile where all of the values will appear grey.
<img width="378" alt="price_change" src="https://user-images.githubusercontent.com/9167204/140661047-774f8eb2-569d-4dc9-bdb2-81de12d208b8.jpg">
 